### PR TITLE
HOTFIX: line chart being clip, add padding-top to fix it

### DIFF
--- a/packages/next/components/charts/lineChart.js
+++ b/packages/next/components/charts/lineChart.js
@@ -25,7 +25,7 @@ export default function LineChart({
     <ChartWrapper>
       <Title>{token} · Last 30d</Title>
       {data.length ? (
-        <Chart padding={[0, 0, 0, 0]} width={227} height={34} data={data}>
+        <Chart padding={[2, 0, 0, 0]} width={227} height={34} data={data}>
           <Axis name="time" visible={false} />
           <Axis name="price" visible={false} />
           <LineAdvance


### PR DESCRIPTION
# after
![image](https://user-images.githubusercontent.com/12393771/127416226-96fade39-9e84-4c74-bb87-d1e5de332635.png)

#  before
![image](https://user-images.githubusercontent.com/12393771/127416227-e960e7b0-8caf-462c-9c5a-edb29c39f385.png)
